### PR TITLE
Dotfiles QoL improvements

### DIFF
--- a/git/install
+++ b/git/install
@@ -7,6 +7,8 @@ stashCommon="-c core.pager='less -SRF' stash list --date=human --format='%C(yell
 # general config
 git config --global credential.helper store
 git config --global push.default simple
+# `git p` works on a branch that has no upstream yet, which is all `pn` did
+git config --global push.autoSetupRemote true
 git config --global fetch.prune true
 git config --global pull.rebase true
 git config --global diff.tool vimdiff
@@ -87,7 +89,8 @@ git config --global alias.aco "!f() { git add --all && git commit -m \"\$1\"; };
 git config --global alias.acop "!f() { git add --all && git commit -m \"\$1\" && git push --follow-tags; }; f"
 
 git config --global alias.p "push --follow-tags"
-git config --global alias.pn "!f() { currentBranch=\$(git rev-parse --abbrev-ref HEAD); git push -u \${1:-origin} \$currentBranch; }; f"
+# Superseded by push.autoSetupRemote; drop it from machines that already have it
+git config --global --unset alias.pn
 git config --global alias.pf "push --force-with-lease"
 
 git config --global alias.c "checkout"

--- a/git/install
+++ b/git/install
@@ -11,6 +11,9 @@ git config --global push.default simple
 git config --global push.autoSetupRemote true
 git config --global fetch.prune true
 git config --global pull.rebase true
+# Cleaner hunk boundaries on reordered blocks, which is also what diff.colorMoved
+# below has to work with
+git config --global diff.algorithm histogram
 git config --global diff.tool vimdiff
 git config --global merge.tool vimdiff
 git config --global core.editor vim

--- a/git/install
+++ b/git/install
@@ -22,6 +22,12 @@ git config --global grep.extendedRegexp true
 git config --global help.autoCorrect prompt
 git config --global rerere.enabled true
 
+# `git b` and `git tl` list most-recent first, in columns instead of one per line
+git config --global branch.sort -committerdate
+git config --global tag.sort -version:refname
+git config --global column.ui auto
+
+
 # Global ignore file, e.g. for system specific ignores
 touch ~/.gitignore
 git config --global core.excludesfile ~/.gitignore

--- a/git/install
+++ b/git/install
@@ -7,12 +7,11 @@ stashCommon="-c core.pager='less -SRF' stash list --date=human --format='%C(yell
 # general config
 git config --global credential.helper store
 git config --global push.default simple
-# `git p` works on a branch that has no upstream yet, which is all `pn` did
+# git push works also on a branch that has no upstream yet
 git config --global push.autoSetupRemote true
 git config --global fetch.prune true
 git config --global pull.rebase true
-# Cleaner hunk boundaries on reordered blocks, which is also what diff.colorMoved
-# below has to work with
+# Cleaner hunk boundaries on reordered blocks
 git config --global diff.algorithm histogram
 git config --global diff.tool vimdiff
 git config --global merge.tool vimdiff
@@ -22,7 +21,7 @@ git config --global grep.extendedRegexp true
 git config --global help.autoCorrect prompt
 git config --global rerere.enabled true
 
-# `git b` and `git tl` list most-recent first, in columns instead of one per line
+# list branches and tags most-recent first, in columns instead of one per line
 git config --global branch.sort -committerdate
 git config --global tag.sort -version:refname
 git config --global column.ui auto
@@ -98,8 +97,6 @@ git config --global alias.aco "!f() { git add --all && git commit -m \"\$1\"; };
 git config --global alias.acop "!f() { git add --all && git commit -m \"\$1\" && git push --follow-tags; }; f"
 
 git config --global alias.p "push --follow-tags"
-# Superseded by push.autoSetupRemote; drop it from machines that already have it
-git config --global --unset alias.pn
 git config --global alias.pf "push --force-with-lease"
 
 git config --global alias.c "checkout"

--- a/git/uninstall
+++ b/git/uninstall
@@ -13,6 +13,9 @@ git config --global --unset color.status
 git config --global --unset grep.extendedRegexp
 git config --global --unset help.autoCorrect
 git config --global --unset rerere.enabled
+git config --global --unset branch.sort
+git config --global --unset tag.sort
+git config --global --unset column.ui
 
 
 # delta stuff (https://dandavison.github.io/delta)

--- a/git/uninstall
+++ b/git/uninstall
@@ -5,6 +5,7 @@ git config --global --unset push.default
 git config --global --unset push.autoSetupRemote
 git config --global --unset fetch.prune
 git config --global --unset pull.rebase
+git config --global --unset diff.algorithm
 git config --global --unset diff.tool
 git config --global --unset merge.tool
 git config --global --unset core.editor

--- a/git/uninstall
+++ b/git/uninstall
@@ -2,6 +2,7 @@
 
 git config --global --unset credential.helper
 git config --global --unset push.default
+git config --global --unset push.autoSetupRemote
 git config --global --unset fetch.prune
 git config --global --unset pull.rebase
 git config --global --unset diff.tool

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -129,7 +129,7 @@ setw -g mode-keys vi
 set -g default-terminal "screen-256color"
 set -g window-size smallest
 
-set -g history-limit 10000
+set -g history-limit 50000
 
 # enable activity alerts
 setw -g monitor-activity on

--- a/toolbox/init.zsh
+++ b/toolbox/init.zsh
@@ -34,7 +34,12 @@ compdef scripts_completion \#
 \#() {
 	if [ $# -eq 0 ]
 	then
-		args=$(printf "%s\n" "${cmds[@]}" | fzf | awk '{print $1}')
+		# Usage line and help text come from _info.toml, which the picker
+		# otherwise never shows.
+		args=$(printf "%s\n" "${cmds[@]}" \
+			| fzf --preview "$scripts_path/_run.py help {}" \
+			      --preview-window=right:55%:wrap \
+			| awk '{print $1}')
 	else
 		args=( $@ )
 	fi

--- a/toolbox/init.zsh
+++ b/toolbox/init.zsh
@@ -8,7 +8,7 @@ descs=( ${(f)"$($scripts_path/_run.py --details)"} )
 
 scripts_completion() {
 	#see also https://stackoverflow.com/a/73356136
-	if [[ $CURRENT > 2 ]]
+	if (( CURRENT > 2 ))
 	then
 		shift words
 		((CURRENT--))

--- a/toolbox/scripts/_run.py
+++ b/toolbox/scripts/_run.py
@@ -51,6 +51,21 @@ def script_info(name):
     return info if isinstance(info, dict) else None
 
 
+def usage_line(name, info):
+    parts = []
+    for arg in (info or {}).get("args", []):
+        default_value = arg.get("default")
+        default = (
+            f" = {default_value}"
+            if default_value is not None and default_value is not False
+            else ""
+        )
+        parts.append(
+            f"[{arg['name']}{default}]" if arg.get("optional") else f"<{arg['name']}>"
+        )
+    return f"Usage: {name} {' '.join(parts)}".rstrip()
+
+
 if argv and argv[0] == "--details":
     print(f"help:{ESC}[0;32;2mShow help for given command{ESC}[0m")
     for script in scripts:
@@ -93,23 +108,7 @@ if argv and argv[0] == "help":
         sys.exit(1)
 
     info = script_info(script_name)
-    args_help = ""
-    if info is not None and "args" in info:
-        parts = []
-        for arg in info["args"]:
-            default_value = arg.get("default")
-            default = (
-                f" = {default_value}"
-                if default_value is not None and default_value is not False
-                else ""
-            )
-            parts.append(
-                f"[{arg['name']}{default}]"
-                if arg.get("optional")
-                else f"<{arg['name']}>"
-            )
-        args_help = " ".join(parts)
-    print(f"Usage: {script_name} {args_help}")
+    print(usage_line(script_name, info))
 
     if info is not None and "help" in info:
         print("")
@@ -131,13 +130,14 @@ if info is not None and "args" in info:
     mandatory_args = [arg for arg in args if not arg.get("optional")]
 
     if len(cmd_args) < len(mandatory_args):
-        print("Error: Missing args:")
         missing = [arg["name"] for arg in mandatory_args][len(cmd_args) :]
-        print("\n".join(missing))
+        print(f"Error: Missing args: {', '.join(missing)}")
+        print(usage_line(script_name, info))
         sys.exit(1)
 
     if len(cmd_args) > len(args):
-        print("Error: Too many args")
+        print(f"Error: Too many args, expected at most {len(args)}")
+        print(usage_line(script_name, info))
         sys.exit(1)
 
 print(script_name)

--- a/toolbox/scripts/_run.py
+++ b/toolbox/scripts/_run.py
@@ -81,6 +81,13 @@ if argv and argv[0] == "--completion":
 if argv and argv[0] == "help":
     script_name = argv[1] if len(argv) > 1 else None
 
+    # "help" is a command in --list, so the picker previews it like any other
+    if script_name == "help":
+        print("Usage: help <command>")
+        print("")
+        print("Show help for given command")
+        sys.exit(1)
+
     if script_name not in scripts:
         print(f"Unknown script {script_name or ''}")
         sys.exit(1)

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -70,7 +70,12 @@ SAVEHIST=20000
 
 setopt hist_ignore_all_dups
 setopt hist_ignore_space
-setopt inc_append_history
+# Subsumes inc_append_history and additionally imports what other shells wrote,
+# so panes see each other's history instead of only appending to the same file
+setopt share_history
+# Timestamps in the history file, which the prompt already reports per command
+setopt extended_history
+setopt hist_reduce_blanks
 setopt nonomatch
 setopt prompt_subst
 setopt correct

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -124,6 +124,22 @@ autoload -U down-line-or-beginning-search
 zle -N down-line-or-beginning-search
 bindkey "$ZSH_HISTORY_KEY_DOWN" down-line-or-beginning-search
 
+# ~/.fzf.zsh is written by the fzf installer that setup.py runs. Sourced here
+# rather than from ~/.zshrc so it lands after `bindkey -v`, as fzf binds into
+# whichever keymap is active.
+[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+# Selected line mirrors the prompt's primary tile, matches use the accent.
+# Colours only: several scripts pass their own --reverse/--height, and popups
+# would shrink if a height were forced here.
+if isProgramInstalled fzf
+then
+  export FZF_DEFAULT_OPTS="\
+--color=fg+:$primaryFg,bg+:$primaryBg,hl:$accentText,hl+:$accentText \
+--color=pointer:$accentText,marker:$accentText,prompt:$primaryText \
+--color=info:$secondaryText,spinner:$accentText,header:$secondaryText,border:$secondaryText"
+fi
+
 
 export ASDF_RUBY_BUILD_VERSION=master
 # Don't do that, some gems don't care about frozen and will crash with this set as default

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -129,14 +129,8 @@ autoload -U down-line-or-beginning-search
 zle -N down-line-or-beginning-search
 bindkey "$ZSH_HISTORY_KEY_DOWN" down-line-or-beginning-search
 
-# ~/.fzf.zsh is written by the fzf installer that setup.py runs. Sourced here
-# rather than from ~/.zshrc so it lands after `bindkey -v`, as fzf binds into
-# whichever keymap is active.
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
-# Selected line mirrors the prompt's primary tile, matches use the accent.
-# Colours only: several scripts pass their own --reverse/--height, and popups
-# would shrink if a height were forced here.
 if isProgramInstalled fzf
 then
   export FZF_DEFAULT_OPTS="\


### PR DESCRIPTION
Nine QoL changes, one commit per topic. Started as twelve requested items; three were dropped after testing or review (see below).

Every change was verified against a discriminating baseline — the assertion was run before the change and had to fail.

## Commits

| Change | Verification |
|--------|--------------|
| Source fzf in `zsh/zshrc` and theme it from the colour scheme | Pty with a clean `PATH`: `^R` is `redisplay` before, `fzf-history-widget` after, and `FZF_DEFAULT_OPTS` is exported in a first login shell |
| Show help in a preview pane in the `#` picker | Pty: typed `encrypt`/`set-them`/`help`, usage + help text render in the pane |
| Replace the `pn` alias with `push.autoSetupRemote` | Throwaway remote: "no upstream branch" before, branch created + tracked after |
| Use the histogram diff algorithm | Differs from myers on 11 of 60 real commits; inspected case keeps a four-line removal contiguous instead of splitting it around a blank line |
| Sort branches and tags by recency, list them in columns | Tags go `v1.0.0/v1.10.0/v1.2.0/v2.0.0` → `v2.0.0/v1.10.0/v1.2.0/v1.0.0`; five branches collapse to one line on a real tty |
| Raise tmux `history-limit` to 50000 | Measured RSS 15MB → 61MB on a pane saturated with 180-char lines (~1kB/line/pane) |
| Print the usage line on toolbox arity errors | `# encrypt-clone` now prints the signature alongside the missing-arg names |
| Share zsh history between shells and timestamp it | Two concurrent pty shells: an already-running shell saw the other pane's command 0 times before, 1 after |
| Compare `CURRENT` arithmetically in the toolbox completer | `[[ $CURRENT > 2 ]]` is a string compare; words 10–19 flip from listing commands to completing arguments. `"25" > "2"` is true lexicographically, which is why it never showed on longer lines |

## Dropped

**`core.fsmonitor` / `core.untrackedCache`.** The latency win was real (interleaved A/B on a 4.5k-file repo: median 35ms → 10ms) but `--global` starts a daemon per repository — measured 91 daemons holding 467MB on one machine after an hour. `core.untrackedCache=true` additionally skips the mtime sanity check that `auto` applies, whose failure mode is a silently stale `git status` — which is exactly what the prompt renders. Per-repo opt-in beats paying that everywhere, not least on a Pi.

**Per-argument-position completion.** The mechanism worked and resolved the `TODO` in `init.zsh`, but no script in the toolbox has genuinely positional arguments with statically listable values. The two migrated to demonstrate it (`tmux-snapshot`, `git-branch-diff`) both parse order-independent flags via `ARGV.include?`, so tying them to positions made `-p` uncompletable at position 1 and dropped `git-branch-diff`'s branch slot through to filename completion. The useful version of this idea is a `completion_command` key so a branch slot could run `git for-each-ref` — a real feature, out of scope here.

**Copy-mode yank over SSH.** Proposed as a silent-failure bug; it isn't one. The tmux buffer is populated identically across all four combinations of `set-clipboard` = `external`/`on` and raw-xclip / guarded copy command with `DISPLAY` unset, `external` already emits OSC 52, and on the paste leg a failing `xclip -o` leaves the previous buffer intact. All that remained was one line to a stderr stream tmux already discards.

## Review

A per-dimension review swarm (6 dimensions, 29 raw findings, 9 confirmed after an adversarial pass) ran over the branch. It caught three real problems, two of which are why items were dropped above; the third was an `fzf` block whose guard was false in a first login shell, since fzf only reaches `PATH` via `~/.fzf.zsh` — the original pty test passed only because it inherited an already-patched `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
